### PR TITLE
fix: Do not reset array items

### DIFF
--- a/src/mson_to_json_schema.js
+++ b/src/mson_to_json_schema.js
@@ -5,14 +5,10 @@ function convertMsonToJsonSchema(content, options) {
     var mson = content.content[0];
     var schema = convert(mson, options);
     if (schema.type === 'array') {
-        var fixedType = false;
         if (mson.attributes && mson.attributes.typeAttributes) {
             fixedType = mson.attributes.typeAttributes.some(function (typeAttr) {
                 return typeAttr === 'fixedType';
             });
-        }
-        if (!fixedType) {
-            return { type: 'array', items: {} }; // reset items schema
         }
     }
     return schema;
@@ -60,7 +56,6 @@ function convert(mson, options) {
         if (member.meta && member.meta.description) {
             propertySchema.description = member.meta.description;
         }
-        var fixedType = false;
         if (member.attributes && member.attributes.typeAttributes) {
             member.attributes.typeAttributes.forEach(function (typeAttr) {
                 switch (typeAttr) {
@@ -79,9 +74,6 @@ function convert(mson, options) {
                         break;
                 }
             });
-        }
-        if (propertySchema.type === 'array' && !fixedType) {
-            propertySchema.items = {}; // reset item schema
         }
         schema.properties[member.content.key.content] = propertySchema;
     }

--- a/test/output/09. Advanced Attributes.json
+++ b/test/output/09. Advanced Attributes.json
@@ -200,7 +200,9 @@
     },
     "Coupons": {
       "type": "array",
-      "items": {}
+      "items": {
+        "$ref": "#/definitions/Coupon"
+      }
     }
   },
   "securityDefinitions": {},

--- a/test/output/09. Advanced Attributes.ref.json
+++ b/test/output/09. Advanced Attributes.ref.json
@@ -165,7 +165,9 @@
     },
     "Coupons": {
       "type": "array",
-      "items": {}
+      "items": {
+        "$ref": "#/definitions/Coupon"
+      }
     }
   },
   "securityDefinitions": {},

--- a/test/output/10. Data Structures.json
+++ b/test/output/10. Data Structures.json
@@ -189,7 +189,9 @@
     },
     "Coupons": {
       "type": "array",
-      "items": {}
+      "items": {
+        "$ref": "#/definitions/Coupon"
+      }
     },
     "Coupon Base": {
       "type": "object",

--- a/test/output/10. Data Structures.ref.json
+++ b/test/output/10. Data Structures.ref.json
@@ -154,7 +154,9 @@
     },
     "Coupons": {
       "type": "array",
-      "items": {}
+      "items": {
+        "$ref": "#/definitions/Coupon"
+      }
     },
     "Coupon Base": {
       "type": "object",

--- a/test/output/Issue-#15.json
+++ b/test/output/Issue-#15.json
@@ -300,7 +300,10 @@
           "properties": {
             "privileges": {
               "type": "array",
-              "items": {},
+              "items": {
+                "type": "string",
+                "example": "[\"add_users\"]"
+              },
               "description": "List of privileges the user has"
             }
           }

--- a/test/output/Issue-#15.ref.json
+++ b/test/output/Issue-#15.ref.json
@@ -81,7 +81,9 @@
             },
             "schema": {
               "type": "array",
-              "items": {}
+              "items": {
+                "$ref": "#/definitions/User"
+              }
             }
           }
         },
@@ -239,7 +241,10 @@
           "properties": {
             "privileges": {
               "type": "array",
-              "items": {},
+              "items": {
+                "type": "string",
+                "example": "[\"add_users\"]"
+              },
               "description": "List of privileges the user has"
             }
           }

--- a/test/output/Issue-#35.json
+++ b/test/output/Issue-#35.json
@@ -33,7 +33,23 @@
       "properties": {
         "status": {
           "type": "array",
-          "items": {}
+          "items": {
+            "anyOf": [
+              null,
+              {
+                "type": "string",
+                "enum": [
+                  "option1"
+                ]
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "option2"
+                ]
+              }
+            ]
+          }
         }
       }
     }

--- a/test/output/Issue-#35.ref.json
+++ b/test/output/Issue-#35.ref.json
@@ -33,7 +33,23 @@
       "properties": {
         "status": {
           "type": "array",
-          "items": {}
+          "items": {
+            "anyOf": [
+              null,
+              {
+                "type": "string",
+                "enum": [
+                  "option1"
+                ]
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "option2"
+                ]
+              }
+            ]
+          }
         }
       }
     }

--- a/test/output/Issue-#49.ref.json
+++ b/test/output/Issue-#49.ref.json
@@ -57,7 +57,9 @@
             },
             "schema": {
               "type": "array",
-              "items": {}
+              "items": {
+                "$ref": "#/definitions/User"
+              }
             }
           },
           "500": {

--- a/test/output/OpenAPI3_Issue-#58.ref.json
+++ b/test/output/OpenAPI3_Issue-#58.ref.json
@@ -93,7 +93,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {}
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
                 },
                 "example": [
                   {

--- a/test/output/OpenAPI3_attributes.json
+++ b/test/output/OpenAPI3_attributes.json
@@ -1,199 +1,199 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "title": "",
-        "version": "1.0.0",
-        "description": ""
-    },
-    "servers": [
-        {
-            "url": "https://www.testhost.com"
-        }
-    ],
-    "paths": {
-        "/object": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "oneOf": [
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "message": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "otherMessage": {
-                                                    "type": "string"
-                                                },
-                                                "someNum": {
-                                                    "type": "number"
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                "examples": {
-                                    "example1": {
-                                        "value": {
-                                            "message": ""
-                                        }
-                                    },
-                                    "example2": {
-                                        "value": {
-                                            "otherMessage": "",
-                                            "someNum": 0
-                                        }
-                                    }
-                                }
-                            }
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": "1.0.0",
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://www.testhost.com"
+    }
+  ],
+  "paths": {
+    "/object": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string"
                         }
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": []
-            }
-        },
-        "/array/object": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "path": {
-                                                "type": "string"
-                                            },
-                                            "otherMessage": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "otherMessage": {
-                                                        "type": "string"
-                                                    },
-                                                    "someNum": {
-                                                        "type": "number"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "required": [
-                                            "path"
-                                        ]
-                                    }
-                                },
-                                "example":  [
-                                    {
-                                        "path": "/files",
-                                        "otherMessage": {
-                                            "otherMessage": "",
-                                            "someNum": 0
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "example": {
-                                "message": ""
-                            },
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/messages": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "message": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "example": [
-                                    {
-                                        "message": ""
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": []
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Message": {
-                "type": "object",
-                "properties": {
-                    "message": {
-                        "type": "string"
-                    }
-                }
-            },
-            "OtherMessage": {
-                "type": "object",
-                "properties": {
-                    "otherMessage": {
-                        "type": "string"
+                      }
                     },
-                    "someNum": {
-                        "type": "number"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "otherMessage": {
+                          "type": "string"
+                        },
+                        "someNum": {
+                          "type": "number"
+                        }
+                      }
                     }
+                  ]
+                },
+                "examples": {
+                  "example1": {
+                    "value": {
+                      "message": ""
+                    }
+                  },
+                  "example2": {
+                    "value": {
+                      "otherMessage": "",
+                      "someNum": 0
+                    }
+                  }
                 }
+              }
             }
-        }
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": []
+      }
     },
-    "tags": []
+    "/array/object": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "otherMessage": {
+                        "type": "object",
+                        "properties": {
+                          "otherMessage": {
+                            "type": "string"
+                          },
+                          "someNum": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ]
+                  }
+                },
+                "example": [
+                  {
+                    "path": "/files",
+                    "otherMessage": {
+                      "otherMessage": "",
+                      "someNum": 0
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "message": ""
+              },
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messages": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": [
+                  {
+                    "message": ""
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": []
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Message": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "OtherMessage": {
+        "type": "object",
+        "properties": {
+          "otherMessage": {
+            "type": "string"
+          },
+          "someNum": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  },
+  "tags": []
 }

--- a/test/output/OpenAPI3_headers.json
+++ b/test/output/OpenAPI3_headers.json
@@ -1,169 +1,169 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "title": "",
-        "version": "1.0.0",
-        "description": ""
-    },
-    "servers": [
-        {
-            "url": "https://www.testhost.com"
-        }
-    ],
-    "paths": {
-        "/some/resource": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "x-testhost-auth-sign",
-                        "in": "header",
-                        "description": "e.g. signed body",
-                        "required": false,
-                        "example": "signed body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer Admin",
-                        "required": false,
-                        "example": "Bearer Admin",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer User",
-                        "required": false,
-                        "example": "Bearer User",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "someType": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": "1.0.0",
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://www.testhost.com"
+    }
+  ],
+  "paths": {
+    "/some/resource": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
         },
-        "/some/restricted/resource": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Restricted resource",
-                "operationId": "Restricted resource",
-                "description": "Has a duplicate header within a single declaration",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer Admin",
-                        "required": false,
-                        "example": "Bearer Admin",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message1": {
-                                        "type": "string",
-                                        "description": "This is the message description "
-                                    }
-                                }
-                            }
-                        }
-                    }
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "x-testhost-auth-sign",
+            "in": "header",
+            "description": "e.g. signed body",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "signed body"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer Admin",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer Admin"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer User",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer User"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "someType": {
+                    "type": "string"
+                  }
                 }
+              }
             }
-        },
-        "/additional/resource": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Additional resource",
-                "operationId": "Additional resource",
-                "description": "",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "x-testhost-auth-sign",
-                        "in": "header",
-                        "description": "e.g. signed body",
-                        "required": false,
-                        "example": "signed body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer Admin",
-                        "required": false,
-                        "example": "Bearer Admin",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer User",
-                        "required": false,
-                        "example": "Bearer User",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
+          }
         }
+      }
     },
-    "components": {
-        "schemas": {}
+    "/some/restricted/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Restricted resource",
+        "operationId": "Restricted resource",
+        "description": "Has a duplicate header within a single declaration",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer Admin",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer Admin"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message1": {
+                    "type": "string",
+                    "description": "This is the message description "
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
-    "tags": []
+    "/additional/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Additional resource",
+        "operationId": "Additional resource",
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "x-testhost-auth-sign",
+            "in": "header",
+            "description": "e.g. signed body",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "signed body"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer Admin",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer Admin"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer User",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer User"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  },
+  "tags": []
 }

--- a/test/output/OpenAPI3_headers.ref.json
+++ b/test/output/OpenAPI3_headers.ref.json
@@ -1,169 +1,169 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "title": "",
-        "version": "1.0.0",
-        "description": ""
-    },
-    "servers": [
-        {
-            "url": "https://www.testhost.com"
-        }
-    ],
-    "paths": {
-        "/some/resource": {
-            "post": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "x-testhost-auth-sign",
-                        "in": "header",
-                        "description": "e.g. signed body",
-                        "required": false,
-                        "example": "signed body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer Admin",
-                        "required": false,
-                        "example": "Bearer Admin",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer User",
-                        "required": false,
-                        "example": "Bearer User",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "someType": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": "1.0.0",
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://www.testhost.com"
+    }
+  ],
+  "paths": {
+    "/some/resource": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
         },
-        "/some/restricted/resource": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Restricted resource",
-                "operationId": "Restricted resource",
-                "description": "Has a duplicate header within a single declaration",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer Admin",
-                        "required": false,
-                        "example": "Bearer Admin",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message1": {
-                                        "type": "string",
-                                        "description": "This is the message description "
-                                    }
-                                }
-                            }
-                        }
-                    }
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "x-testhost-auth-sign",
+            "in": "header",
+            "description": "e.g. signed body",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "signed body"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer Admin",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer Admin"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer User",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer User"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "someType": {
+                    "type": "string"
+                  }
                 }
+              }
             }
-        },
-        "/additional/resource": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Additional resource",
-                "operationId": "Additional resource",
-                "description": "",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "x-testhost-auth-sign",
-                        "in": "header",
-                        "description": "e.g. signed body",
-                        "required": false,
-                        "example": "signed body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer Admin",
-                        "required": false,
-                        "example": "Bearer Admin",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "e.g. Bearer User",
-                        "required": false,
-                        "example": "Bearer User",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ]
-            }
+          }
         }
+      }
     },
-    "components": {
-        "schemas": {}
+    "/some/restricted/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Restricted resource",
+        "operationId": "Restricted resource",
+        "description": "Has a duplicate header within a single declaration",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer Admin",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer Admin"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message1": {
+                    "type": "string",
+                    "description": "This is the message description "
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
-    "tags": []
+    "/additional/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Additional resource",
+        "operationId": "Additional resource",
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "x-testhost-auth-sign",
+            "in": "header",
+            "description": "e.g. signed body",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "signed body"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer Admin",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer Admin"
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "e.g. Bearer User",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Bearer User"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  },
+  "tags": []
 }

--- a/test/output/OpenAPI3_includes.json
+++ b/test/output/OpenAPI3_includes.json
@@ -1,66 +1,66 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "title": "",
-        "version": "1.0.0",
-        "description": ""
-    },
-    "servers": [
-        {
-            "url": "https://www.testhost.com"
-        }
-    ],
-    "paths": {
-        "/some/resource": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "./includes/resource-response-schema.json"
-                                },
-                                "examples": {
-                                    "example1": {
-                                        "$ref": "./includes/resource-response-body.json"
-                                    },
-                                    "example2": {
-                                        "$ref": "./includes/resource-response-body-2.json"
-                                    }
-                                }
-                            }
-                        }
-                    }
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": "1.0.0",
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://www.testhost.com"
+    }
+  ],
+  "paths": {
+    "/some/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./includes/resource-response-schema.json"
                 },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "examples": {
-                                "example1": {
-                                    "$ref": "./includes/resource-request-body.json"
-                                },
-                                "example2": {
-                                    "$ref": "./includes/resource-request-body-2.json"
-                                }
-                            },
-                            "schema": {
-                                "$ref": "./includes/resource-request-schema.json"
-                            }
-                        }
-                    }
+                "examples": {
+                  "example1": {
+                    "$ref": "./includes/resource-response-body.json"
+                  },
+                  "example2": {
+                    "$ref": "./includes/resource-response-body-2.json"
+                  }
                 }
+              }
             }
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "example1": {
+                  "$ref": "./includes/resource-request-body.json"
+                },
+                "example2": {
+                  "$ref": "./includes/resource-request-body-2.json"
+                }
+              },
+              "schema": {
+                "$ref": "./includes/resource-request-schema.json"
+              }
+            }
+          }
         }
-    },
-    "components": {
-        "schemas": {}
-    },
-    "tags": []
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  },
+  "tags": []
 }

--- a/test/output/OpenAPI3_includes.ref.json
+++ b/test/output/OpenAPI3_includes.ref.json
@@ -1,66 +1,66 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "title": "",
-        "version": "1.0.0",
-        "description": ""
-    },
-    "servers": [
-        {
-            "url": "https://www.testhost.com"
-        }
-    ],
-    "paths": {
-        "/some/resource": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "./includes/resource-response-schema.json"
-                                },
-                                "examples": {
-                                    "example1": {
-                                        "$ref": "./includes/resource-response-body.json"
-                                    },
-                                    "example2": {
-                                        "$ref": "./includes/resource-response-body-2.json"
-                                    }
-                                }
-                            }
-                        }
-                    }
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": "1.0.0",
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://www.testhost.com"
+    }
+  ],
+  "paths": {
+    "/some/resource": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./includes/resource-response-schema.json"
                 },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "examples": {
-                                "example1": {
-                                    "$ref": "./includes/resource-request-body.json"
-                                },
-                                "example2": {
-                                    "$ref": "./includes/resource-request-body-2.json"
-                                }
-                            },
-                            "schema": {
-                                "$ref": "./includes/resource-request-schema.json"
-                            }
-                        }
-                    }
+                "examples": {
+                  "example1": {
+                    "$ref": "./includes/resource-response-body.json"
+                  },
+                  "example2": {
+                    "$ref": "./includes/resource-response-body-2.json"
+                  }
                 }
+              }
             }
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "example1": {
+                  "$ref": "./includes/resource-request-body.json"
+                },
+                "example2": {
+                  "$ref": "./includes/resource-request-body-2.json"
+                }
+              },
+              "schema": {
+                "$ref": "./includes/resource-request-schema.json"
+              }
+            }
+          }
         }
-    },
-    "components": {
-        "schemas": {}
-    },
-    "tags": []
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  },
+  "tags": []
 }

--- a/test/output/OpenAPI3_requests.json
+++ b/test/output/OpenAPI3_requests.json
@@ -1,326 +1,326 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "title": "",
-        "version": "1.0.0",
-        "description": ""
-    },
-    "servers": [
-        {
-            "url": "https://www.testhost.com"
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": "1.0.0",
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://www.testhost.com"
+    }
+  ],
+  "paths": {
+    "/some/resource/{pathParam}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "pathParam",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "example": "exampleValue",
+            "schema": {
+              "type": "string",
+              "default": "defaultValue"
+            }
+          },
+          {
+            "name": "queryParam",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "example": "value1",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "value1",
+                "value2"
+              ]
+            }
+          },
+          {
+            "name": "additionalQueryParam",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message1": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message2": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message3": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
         }
-    ],
-    "paths": {
-        "/some/resource/{pathParam}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "pathParam",
-                        "in": "path",
-                        "description": "",
-                        "required": true,
-                        "example": "exampleValue",
-                        "schema": {
-                            "type": "string",
-                            "default": "defaultValue"
-                        }
-                    },
-                    {
-                        "name": "queryParam",
-                        "in": "query",
-                        "description": "",
-                        "required": true,
-                        "example": "value1",
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "value1",
-                                "value2"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "additionalQueryParam",
-                        "in": "query",
-                        "description": "",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message1": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message2": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message3": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/another/resource/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Another resource",
-                "operationId": "Another resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "examples": {
-                                "example1": {
-                                    "value": {
-                                        "message1": "Hello world"
-                                    }
-                                },
-                                "example2": {
-                                    "value": {
-                                        "message2": "Hello world"
-                                    }
-                                }
-                            },
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message1": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message2": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/withAttributes": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "example": {
-                                "message": ""
-                            },
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "someType": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/onlyAttributes": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Message"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/onlyExamples": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "examples": {
-                                "example1": {
-                                    "value": {
-                                        "message": "test1"
-                                    }
-                                },
-                                "example2": {
-                                    "value": {
-                                        "message": "test2"
-                                    }
-                                },
-                                "example3": {
-                                    "value": {
-                                        "message": "test3"
-                                    }
-                                }
-                            },
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "text/plain": {
-                            "example": "test\n"
-                        }
-                    }
-                }
-            }
-        },
-        "/bodyOnly": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "example": {
-                                "message": "test2"
-                            },
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+      }
     },
-    "components": {
-        "schemas": {
-            "Message": {
+    "/another/resource/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Another resource",
+        "operationId": "Another resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "example1": {
+                  "value": {
+                    "message1": "Hello world"
+                  }
+                },
+                "example2": {
+                  "value": {
+                    "message2": "Hello world"
+                  }
+                }
+              },
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message1": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message2": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/withAttributes": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "message": ""
+              },
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "someType": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/onlyAttributes": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/onlyExamples": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "example1": {
+                  "value": {
+                    "message": "test1"
+                  }
+                },
+                "example2": {
+                  "value": {
+                    "message": "test2"
+                  }
+                },
+                "example3": {
+                  "value": {
+                    "message": "test3"
+                  }
+                }
+              },
+              "schema": {
                 "type": "object",
                 "properties": {
-                    "message": {
-                        "type": "string"
-                    }
+                  "message": {
+                    "type": "string"
+                  }
                 }
+              }
+            },
+            "text/plain": {
+              "example": "test\n"
             }
+          }
         }
+      }
     },
-    "tags": []
+    "/bodyOnly": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "message": "test2"
+              },
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Message": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": []
 }

--- a/test/output/OpenAPI3_requests.ref.json
+++ b/test/output/OpenAPI3_requests.ref.json
@@ -1,321 +1,321 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "title": "",
-        "version": "1.0.0",
-        "description": ""
-    },
-    "servers": [
-        {
-            "url": "https://www.testhost.com"
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "version": "1.0.0",
+    "description": ""
+  },
+  "servers": [
+    {
+      "url": "https://www.testhost.com"
+    }
+  ],
+  "paths": {
+    "/some/resource/{pathParam}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [
+          {
+            "name": "pathParam",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "example": "exampleValue",
+            "schema": {
+              "type": "string",
+              "default": "defaultValue"
+            }
+          },
+          {
+            "name": "queryParam",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "example": "value1",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "value1",
+                "value2"
+              ]
+            }
+          },
+          {
+            "name": "additionalQueryParam",
+            "in": "query",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message1": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message2": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message3": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
         }
-    ],
-    "paths": {
-        "/some/resource/{pathParam}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [
-                    {
-                        "name": "pathParam",
-                        "in": "path",
-                        "description": "",
-                        "required": true,
-                        "example": "exampleValue",
-                        "schema": {
-                            "type": "string",
-                            "default": "defaultValue"
-                        }
-                    },
-                    {
-                        "name": "queryParam",
-                        "in": "query",
-                        "description": "",
-                        "required": true,
-                        "example": "value1",
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "value1",
-                                "value2"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "additionalQueryParam",
-                        "in": "query",
-                        "description": "",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message1": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message2": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message3": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/another/resource/": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Another resource",
-                "operationId": "Another resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "examples": {
-                                "example1": {
-                                    "value": {
-                                        "message1": "Hello world"
-                                    }
-                                },
-                                "example2": {
-                                    "value": {
-                                        "message2": "Hello world"
-                                    }
-                                }
-                            },
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message1": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "message2": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/withAttributes": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "example": {
-                                "message": ""
-                            },
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "someType": {
-                                                "type": "string",
-                                                "description": "This is the message description "
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Message"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/onlyAttributes": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Message"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/onlyExamples": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "examples": {
-                                "example1": {
-                                    "value": {
-                                        "message": "test1"
-                                    }
-                                },
-                                "example2": {
-                                    "value": {
-                                        "message": "test2"
-                                    }
-                                },
-                                "example3": {
-                                    "value": {
-                                        "message": "test3"
-                                    }
-                                }
-                            },
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "text/plain": {
-                            "example": "test\n"
-                        }
-                    }
-                }
-            }
-        },
-        "/bodyOnly": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "headers": {},
-                        "content": {}
-                    }
-                },
-                "summary": "Some resource",
-                "operationId": "Some resource",
-                "description": "",
-                "tags": [],
-                "parameters": [],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "example": {
-                                "message": "test2"
-                            },
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+      }
     },
-    "components": {
-        "schemas": {
-            "Message": {
+    "/another/resource/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Another resource",
+        "operationId": "Another resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "example1": {
+                  "value": {
+                    "message1": "Hello world"
+                  }
+                },
+                "example2": {
+                  "value": {
+                    "message2": "Hello world"
+                  }
+                }
+              },
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message1": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "message2": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/withAttributes": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "message": ""
+              },
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "someType": {
+                        "type": "string",
+                        "description": "This is the message description "
+                      }
+                    }
+                  },
+                  {
+                    "$ref": "#/components/schemas/Message"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/onlyAttributes": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Message"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/onlyExamples": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "examples": {
+                "example1": {
+                  "value": {
+                    "message": "test1"
+                  }
+                },
+                "example2": {
+                  "value": {
+                    "message": "test2"
+                  }
+                },
+                "example3": {
+                  "value": {
+                    "message": "test3"
+                  }
+                }
+              },
+              "schema": {
                 "type": "object",
                 "properties": {
-                    "message": {
-                        "type": "string"
-                    }
+                  "message": {
+                    "type": "string"
+                  }
                 }
+              }
+            },
+            "text/plain": {
+              "example": "test\n"
             }
+          }
         }
+      }
     },
-    "tags": []
+    "/bodyOnly": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {},
+            "content": {}
+          }
+        },
+        "summary": "Some resource",
+        "operationId": "Some resource",
+        "description": "",
+        "tags": [],
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "message": "test2"
+              },
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Message": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": []
 }


### PR DESCRIPTION
The main changes here are to the `mson_to_json_schema.js` file, with the rest of the changes being autogenerated test changes. However, the test files give a sense of what the effects of these changes are.

This comes out of work to generate client-side fetches using `orval`, which creates typescript schemae based on the OpenAPI spec. However, because all array-typed elements were getting their `items` set to plain objects, the resulting types were inaccurate, and there was little benefit to the type hinting included in the fetches.

E.g., in the PaginatedContentList schema for one of our metadata endpoints, I was getting this value in the generated OpenAPI file:
![Screenshot 2025-02-06 at 4 28 03 PM](https://github.com/user-attachments/assets/9b5cd3d3-68ff-4909-98a8-9de162873481)

And following this change, it is instead keeping the ref to the correct `Content` Schema:
![Screenshot 2025-02-06 at 4 27 40 PM](https://github.com/user-attachments/assets/485b8783-b92b-42df-a850-51bfbb9e07f9)

I have run this through 6 of our repos locally and have only found this change to be an improvement over our current OpenAPI output; however, I wasn't entirely able to get to the bottom of _why_ the original library's author had these blocks included to reset these `array.items` values, so it's possible that this will cause issues I can't currently foresee. However, as a stopgap while we work to transition our api documentation over to native OpenAPI files, this will hopefully get us more valuable output.

